### PR TITLE
팔로우 API 구현

### DIFF
--- a/src/main/java/com/bom/newsfeed/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/bom/newsfeed/domain/follow/controller/FollowController.java
@@ -1,0 +1,44 @@
+package com.bom.newsfeed.domain.follow.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bom.newsfeed.domain.follow.service.FollowService;
+import com.bom.newsfeed.domain.member.dto.MemberDto;
+import com.bom.newsfeed.global.annotation.CurrentMember;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "팔로우 API", description = "팔로우 API 컨트롤러")
+@RequestMapping("/api/follow")
+@RestController
+public class FollowController {
+
+	private final FollowService followService;
+
+	public FollowController(FollowService followService) {
+		this.followService = followService;
+	}
+
+	//팔로우 등록
+	@PostMapping("/{followingId}")
+	public void follow(
+		@PathVariable(name = "followingId") Long followingId,
+		@CurrentMember MemberDto memberDto
+	) {
+		followService.follow(followingId, memberDto);
+	}
+
+	//팔로우 취소
+	@DeleteMapping("/{followingId}")
+	public void unFollow(
+		@PathVariable(name = "followingId") Long followingId,
+		@CurrentMember MemberDto memberDto
+	) {
+		followService.unFollow(followingId, memberDto);
+
+	}
+}

--- a/src/main/java/com/bom/newsfeed/domain/follow/entity/Follow.java
+++ b/src/main/java/com/bom/newsfeed/domain/follow/entity/Follow.java
@@ -1,0 +1,32 @@
+package com.bom.newsfeed.domain.follow.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(FollowPk.class)
+@Table(name = "follow")
+@Entity
+public class Follow {
+	@Id
+	@JoinColumn(name = "member_id")
+	private Long followerId; //팔로워
+	@Id
+	@JoinColumn(name = "member_id")
+	private Long followingId; //팔로잉
+
+	public Follow(Long followerId, Long followingId) {
+		this.followerId = followerId;
+		this.followingId = followingId;
+	}
+
+
+	public static Follow of(Long followerId, Long followingId) {
+		return new Follow(followerId, followingId);
+	}
+}

--- a/src/main/java/com/bom/newsfeed/domain/follow/entity/FollowPk.java
+++ b/src/main/java/com/bom/newsfeed/domain/follow/entity/FollowPk.java
@@ -1,0 +1,22 @@
+package com.bom.newsfeed.domain.follow.entity;
+
+import java.io.Serializable;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class FollowPk implements Serializable {
+	private Long followerId;
+	private Long followingId;
+
+	public static FollowPk of(Long followerId, Long followingId) {
+		return new FollowPk(followerId, followingId);
+	}
+}

--- a/src/main/java/com/bom/newsfeed/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/bom/newsfeed/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,10 @@
+package com.bom.newsfeed.domain.follow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bom.newsfeed.domain.follow.entity.Follow;
+import com.bom.newsfeed.domain.follow.entity.FollowPk;
+
+public interface FollowRepository extends JpaRepository<Follow, FollowPk> {
+
+}

--- a/src/main/java/com/bom/newsfeed/domain/follow/service/FollowService.java
+++ b/src/main/java/com/bom/newsfeed/domain/follow/service/FollowService.java
@@ -1,0 +1,64 @@
+package com.bom.newsfeed.domain.follow.service;
+
+import static com.bom.newsfeed.global.exception.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bom.newsfeed.domain.follow.entity.Follow;
+import com.bom.newsfeed.domain.follow.entity.FollowPk;
+import com.bom.newsfeed.domain.follow.repository.FollowRepository;
+import com.bom.newsfeed.domain.member.dto.MemberDto;
+import com.bom.newsfeed.domain.member.repository.MemberRepository;
+import com.bom.newsfeed.global.exception.AlreadyExistFollowingException;
+import com.bom.newsfeed.global.exception.ApiException;
+import com.bom.newsfeed.global.exception.FollowingNotFoundException;
+import com.bom.newsfeed.global.exception.MemberNotFoundException;
+
+@Service
+public class FollowService {
+	private final FollowRepository followRepository;
+	private final MemberRepository memberRepository;
+
+	public FollowService(FollowRepository followRepository, MemberRepository memberRepository) {
+		this.followRepository = followRepository;
+		this.memberRepository = memberRepository;
+	}
+
+	@Transactional
+	public void follow(Long followingId, MemberDto follower) {
+		//팔로잉할 회원정보가 존재하는지 확인
+		if (!memberRepository.existsById(followingId)) {
+			throw new MemberNotFoundException();
+		}
+
+		//자기자신을 팔로우하는건지 확인
+		if(followingId.equals(follower.getId())) {
+			throw new ApiException(INVALID_VALUE);
+		}
+
+		//이미 팔로잉 했는지 확인
+		FollowPk id = FollowPk.of(follower.getId(), followingId);
+		if (followRepository.existsById(id)) {
+			throw new AlreadyExistFollowingException();
+		}
+
+		Follow follow = Follow.of(id.getFollowerId(), id.getFollowingId());
+		followRepository.save(follow);
+	}
+
+	@Transactional
+	public void unFollow(Long followingId, MemberDto follower) {
+		//팔로잉 취소 할 회원정보가 존재하는지 확인
+		if (!memberRepository.existsById(followingId)) {
+			throw new MemberNotFoundException();
+		}
+
+		//Follow 찾기
+		FollowPk id = FollowPk.of(follower.getId(), followingId);
+		Follow follow = followRepository.findById(id)
+			.orElseThrow(FollowingNotFoundException::new);
+
+		followRepository.delete(follow);
+	}
+}

--- a/src/main/java/com/bom/newsfeed/global/exception/AlreadyExistFollowingException.java
+++ b/src/main/java/com/bom/newsfeed/global/exception/AlreadyExistFollowingException.java
@@ -1,0 +1,7 @@
+package com.bom.newsfeed.global.exception;
+
+public class AlreadyExistFollowingException extends ApiException{
+	public AlreadyExistFollowingException() {
+		super(ErrorCode.ALREADY_EXIST_FOLLOWING);
+	}
+}

--- a/src/main/java/com/bom/newsfeed/global/exception/ErrorCode.java
+++ b/src/main/java/com/bom/newsfeed/global/exception/ErrorCode.java
@@ -24,12 +24,14 @@ public enum ErrorCode {
     ACCESS_DENIED(FORBIDDEN, "권한이 없습니다."),
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
     MEMBER_NOT_FOUND(NOT_FOUND, "해당 회원 정보를 찾을 수 없습니다"),
+    FOLLOWING_NOT_FOUND(NOT_FOUND, "팔로잉한 회원 정보를 찾을 수 없습니다"),
 
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(CONFLICT, "데이터가 이미 존재합니다"),
     ALREADY_EXIST_MEMBER(CONFLICT, "이미 존재하는 회원입니다."),
     ALREADY_EXIST_NICKNAME(CONFLICT, "이미 존재하는 닉네임입니다."),
+    ALREADY_EXIST_FOLLOWING(CONFLICT, "이미 팔로잉한 회원입니다."),
 
 
     /* 500 INTERNAL_SERVER_ERROR : 서버 에러 */

--- a/src/main/java/com/bom/newsfeed/global/exception/FollowingNotFoundException.java
+++ b/src/main/java/com/bom/newsfeed/global/exception/FollowingNotFoundException.java
@@ -1,0 +1,7 @@
+package com.bom.newsfeed.global.exception;
+
+public class FollowingNotFoundException extends ApiException{
+	public FollowingNotFoundException() {
+		super(ErrorCode.FOLLOWING_NOT_FOUND);
+	}
+}


### PR DESCRIPTION
-  팔로우 도메인 설계
> 기존 ERD 설계시에는 팔로우 도메인의 팔로워,팔로잉이 각각 회원과 연관관계를 맺었는데
> 조금 고민을 해보니 팔로우 관계는 팔로우와 회원간의 상태에 따라 결정되는게아니라
> 팔로우 안에 팔로잉과 팔로워에 상태에 따라 결정된다고 생각해서
> 팔로워 id 와 팔로잉 id 를 복합키를 가지게 설계를 했습니다.

다만 추후 팔로잉 정보를 이용한 피드 조회 시 쿼리 성능등에 의하여  테스팅 후 변경될 수 있을 것 같습니다.

- 팔로우 API 구현
- 언팔로우 API 구현

This Closes #25 
